### PR TITLE
Refactor: Extract domain name to constant (fixes #14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animeflv-stremio-addon",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "animeflv-stremio-addon",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@vercel/blob": "^1.1.1",


### PR DESCRIPTION
Fixed issue #14 

I replaced the hard-coded domain names in the stated lines

New lines
line 85:  `${encodeURIComponent(ANIMEFLV_BASE)}%2Fbrowse%3F${(query) ? "q%3D" + encodeURIComponent(query) + "%26" : ""}${(genreArr)? "genre%5B%5D%3D" + genreArr.join("%26genre%5B%5D%3D") : ""}${(page) ? "%26page%3D" + page : ""}`


line 136: thumbnail: `${ANIMEFLV_BASE}/uploads/animes/thumbs/${matches[1]}.jpg`,

line 148: thumbnail: `${ANIMEFLV_BASE}/assets/animeflv/img/cnt/proximo.png`,