### PR TITLE
Add animejara support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,4 @@ onair_titles.json
 onairAV1_titles.json
 onairHENAOJARA_titles.json
 onair_titlesTIO.json
-onair_ANIMEJARA_titles.json
+onairANIMEJARA_titles.json

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ onair_titles.json
 onairAV1_titles.json
 onairHENAOJARA_titles.json
 onair_titlesTIO.json
+onair_ANIMEJARA_titles.json

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
-# [AnimeFLV, AnimeAV1, Henaojara & TioAnime Stremio addon](https://pigamer37.alwaysdata.net/manifest.json)
+# [AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara Stremio addon](https://pigamer37.alwaysdata.net/manifest.json)
 <p align="center"><img src="https://www3.animeflv.net/assets/animeflv/img/logo.png?v=2.3" alt="AnimeFLV logo" width="256"/></p>
 <p align="center"><img src="https://animeav1.com/img/logo-dark.svg" alt="AnimeAV1 logo" width="256"/></p>
 <p align="center"><img src="https://www.henaojara.com/wp-content/uploads/2021/04/INICIO_new.png" alt="Henaojara logo" width="300"/></p>
 <p align="center"><img src="https://tioanime.com/assets/img/logo-dark.png" alt="Henaojara logo" width="256"/></p>
+<p align="center"><img src="https://animejara.com/wp-content/uploads/2025/11/ANIMEJARA_INICIO3.png" alt="AnimeJara logo" width="256"/></p>
 
-Node.js and express.js based addon to add AnimeFLV, AnimeAV1, Henaojara & TioAnime functionallity to Stremio, not affiliated with AnimeFLV, AnimeAV1 Henaojara or TioAnime. (I'm new to backend so I'm using it as a learning experience).
+Node.js and express.js based addon to add AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara functionallity to Stremio, not affiliated with AnimeFLV, AnimeAV1 Henaojara, TioAnime or AnimeJara. (I'm new to backend so I'm using it as a learning experience).
 
 ## Normal use
 ### Install by visiting <https://pigamer37.alwaysdata.net/configure>, or by copying <stremio://pigamer37.alwaysdata.net/manifest.json> on your browser or paste <https://pigamer37.alwaysdata.net/manifest.json> on the Stremio addons search bar :mag: or the Add addon button
 
 ### Features:
 - :tv: Catalog of currently airing anime, to keep up with what is currently being released
-- :mag: Search the AnimeFLV, AnimeAV1, Henaojara & TioAnime databases/catalogs through Stremio's searchbar, or filter them by genre in the Discovery tab
+- :mag: Search the AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara databases/catalogs through Stremio's searchbar, or filter them by genre in the Discovery tab
 - :wrench: Compatible with other addons, like Cinemeta, TMDB or kitsu so you can use your preferred metadata provider (see [supported ID's](#endpoints) for technical details)
-- :page_with_curl: See metadata extracted from AnimeFLV, AnimeAV1, Henaojara & TioAnime natively in Stremio, like synopses/overviews, genres, related media, episode lists and release dates for upcoming episodes
+- :page_with_curl: See metadata extracted from AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara natively in Stremio, like synopses/overviews, genres, related media, episode lists and release dates for upcoming episodes
   - :calendar: If you add series to your library (through an AnimeFLV or TioAnime ID), upcoming episodes will show up in your Stremio calendar!
-- :satellite: Provides stream sources from AnimeFLV, AnimeAV1, Henaojara & TioAnime
+- :satellite: Provides stream sources from AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara
 
-This addon provides metadata and streaming options from AnimeFLV, AnimeAV1, Henaojara & TioAnime. It offers a catalog with airing anime on the homepage, and a searchable catalog of all AnimeFLV, AnimeAV1, Henaojara & TioAnime, even being able to filter by genre. Additionally, when you open an item on Stremio that matches some parameters set in the manifest (generated on [`index.js`](index.js)), or whenever you start watching something, the platform will call this addon. When the program can get the data for the item you are about to watch, some metadata will be provided and/or streaming options will appear as "AnimeFLV ...", "AnimeAV1 ...", "Henaojara ..." or "TioAnime ..." (the ones marked as external open a player on your browser, working on getting more sources to be watchable directly on Stremio. You can add them by [configuring the addon](https://pigamer37.alwaysdata.net/configure), as they are not added by default).
+This addon provides metadata and streaming options from AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara. It offers a catalog with airing anime on the homepage, and a searchable catalog of all AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara, even being able to filter by genre. Additionally, when you open an item on Stremio that matches some parameters set in the manifest (generated on [`index.js`](index.js)), or whenever you start watching something, the platform will call this addon. When the program can get the data for the item you are about to watch, some metadata will be provided and/or streaming options will appear as "AnimeFLV ...", "AnimeAV1 ...", "Henaojara ...", "TioAnime ..." or "AnimeJara ..." (the ones marked as external open a player on your browser, working on getting more sources to be watchable directly on Stremio. You can add them by [configuring the addon](https://pigamer37.alwaysdata.net/configure), as they are not added by default).
 
 > [!TIP]
 > ### Recommendations
@@ -35,16 +36,17 @@ Here's the path to call it (parameters are marked by being enclosed in {} and de
 ```
 Parameters
 1. `resource`: stream and meta are very self explanatory, and catalog exposes a list of anime. 
-   - When using catalog as a resource, you can also call `/catalog/{type}/{ID}/search={query}.json` where `query` is what to search for on AnimeFLV, AnimeAV1, Henaojara & TioAnime , or `/catalog/{type}/{ID}/genre={query}.json` where `query` is the genre ([there's a list of genres in the manifest](index.js#L35), and `query` must match one exactly) to search or filter the whole AnimeFLV/AnimeAV1/Henaojara/TioAnime database. It's defined this way to work with Stremio. Use `animeflv`/`animeav1` or `animeflv|genres`/`animeav1|genres`/`henaojara|genres` as the `ID`, or use `animeflv|onair`/`animeav1|onair`/`henaojara|onair` (without search or genre queries) to get a list of currently airing anime.
+   - When using catalog as a resource, you can also call `/catalog/{type}/{ID}/search={query}.json` where `query` is what to search for on AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara , or `/catalog/{type}/{ID}/genre={query}.json` where `query` is the genre ([there's a list of genres in the manifest](index.js#L35), and `query` must match one exactly) to search or filter the whole AnimeFLV/AnimeAV1/Henaojara/TioAnime database. It's defined this way to work with Stremio. Use `animeflv`/`animeav1` or `animeflv|genres`/`animeav1|genres`/`henaojara|genres` as the `ID`, or use `animeflv|onair`/`animeav1|onair`/`henaojara|onair` (without search or genre queries) to get a list of currently airing anime.
 2. `type`: should not matter, but to make sure, use 'movie' or 'series' depending on what the item is
-3. `ID`: Except for IMDB, different seasons have different ID's. Here we have some options:
+3. `ID`: Except for IMDB & AnimeJara, different seasons have different ID's. Here we have some options:
    - `AnimeFLV ID`: starts with "animeflv:", followed by the series AnimeFLV slug, always. This is the "native" ID type and the one the catalogs the addon offers use. You can specify an episode number if you want. Example: `animeflv:kono-subarashii-sekai-ni-shukufuku-wo:2` *should* give results for Konosuba (Season 1 was specified with the AnimeFLV slug) Episode 2
    - `AnimeAV1 ID`: starts with "animeav1:", followed by the series AnimeAV1 slug, always. This is the "native" ID type and the one the catalogs the addon offers use. You can specify an episode number if you want. Example: `animeav1:kono-subarashii-sekai-ni-shukufuku-wo:2` *should* give results for Konosuba (Season 1 was specified with the AnimeAV1 slug) Episode 2
    - `Henaojara ID`: starts with "henaojara:", followed by the series Henaojara slug, always. This is the "native" ID type and the one the catalogs the addon offers use. You can specify an episode number if you want. Example: `henaojara:kono-subarashii-sekai-ni-shukufuku-wo:2` *should* give results for Konosuba (Season 1 was specified with the Henaojara slug) Episode 2
    - `TioAnime ID`: starts with "tioanime:", followed by the series TioAnime slug, always. This is the "native" ID type and the one the catalogs the addon offers use. You can specify an episode number if you want. Example: `tioanime:kono-subarashii-sekai-ni-shukufuku-wo:2` *should* give results for Konosuba (Season 1 was specified with the TioAnime slug) Episode 2
+   - `AnimeJara ID`: starts with "animejara:", followed by the series AnimeJara slug, always. If you are looking for a series, you can specify the season and episode numbers. Example: `animejara:konosuba:1:2` *should* give results for Konosuba (Season 1) Episode 2
    
    > [!NOTE]
-   > These 3 native ID's usually are the same (like in the example), but sometimes they may differ between them (specially on AnimeAV1).
+   > These 3 native ID's usually are the same (like in the example), but sometimes they may differ between them (specially on AnimeJara).
 
    - `IMDB ID`: starts with "tt", followed by a number, always. If you are looking for a series, you can specify the season and episode numbers. Example: `tt5370118:1:2` *should* give results for Konosuba Season 1 Episode 2
    - `TMDB ID`: starts with "tmdb:", followed by a number, always. You can specify a season and episode number if you want. Example: `tmdb:65844:1:2` *should* give results for Konosuba Season 1 Episode 2
@@ -96,6 +98,9 @@ You can add some configuration before the call. Right now, the only available co
 >
 > <p align="center"><img src="https://tioanime.com/assets/img/logo-dark.png" alt="Henaojara logo" width="256"/></p>
 > This application/addon uses TioAnime but is not endorsed, certified, or otherwise approved by TioAnime.
+>
+> <p align="center"><img src="https://animejara.com/wp-content/uploads/2025/11/ANIMEJARA_INICIO3.png" alt="AnimeJara logo" width="256"/></p>
+> This application/addon uses AnimeJara but is not endorsed, certified, or otherwise approved by AnimeJara.
 >
 > [The unofficial AnimeFLV API](https://animeflv.ahmedrangel.com/api)
 > This application/addon uses the unofficial AnimeFLV API (or its adapted code) but is not endorsed, certified, or otherwise approved by it.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><img src="https://animeav1.com/img/logo-dark.svg" alt="AnimeAV1 logo" width="256"/></p>
 <p align="center"><img src="https://www.henaojara.com/wp-content/uploads/2021/04/INICIO_new.png" alt="Henaojara logo" width="300"/></p>
 <p align="center"><img src="https://tioanime.com/assets/img/logo-dark.png" alt="Henaojara logo" width="256"/></p>
-<p align="center"><img src="https://animejara.com/wp-content/uploads/2025/11/ANIMEJARA_INICIO3.png" alt="AnimeJara logo" width="256"/></p>
+<p align="center"><img src="https://animejara.com/wp-content/uploads/2025/11/ANIMEJARA_INICIO3.png" alt="AnimeJara logo" width="300"/></p>
 
 Node.js and express.js based addon to add AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara functionallity to Stremio, not affiliated with AnimeFLV, AnimeAV1 Henaojara, TioAnime or AnimeJara. (I'm new to backend so I'm using it as a learning experience).
 
@@ -99,7 +99,7 @@ You can add some configuration before the call. Right now, the only available co
 > <p align="center"><img src="https://tioanime.com/assets/img/logo-dark.png" alt="Henaojara logo" width="256"/></p>
 > This application/addon uses TioAnime but is not endorsed, certified, or otherwise approved by TioAnime.
 >
-> <p align="center"><img src="https://animejara.com/wp-content/uploads/2025/11/ANIMEJARA_INICIO3.png" alt="AnimeJara logo" width="256"/></p>
+> <p align="center"><img src="https://animejara.com/wp-content/uploads/2025/11/ANIMEJARA_INICIO3.png" alt="AnimeJara logo" width="300"/></p>
 > This application/addon uses AnimeJara but is not endorsed, certified, or otherwise approved by AnimeJara.
 >
 > [The unofficial AnimeFLV API](https://animeflv.ahmedrangel.com/api)

--- a/index.js
+++ b/index.js
@@ -94,6 +94,23 @@ function ReadManifest() {
           ]
         },
         {
+          id: "animejara", type: "AnimeJara", name: "search results",
+          extra: [{ name: "search", isRequired: true },
+            {
+              name: "genre",
+              options: ["Accion", "Amor", "Artes+marciales", "Aventura", "Carreras", "Ciencia+ficcion", 
+                "Comedia", "Crimen", "Demonios", "Deportes", "Drama", "Ecchi", "Escolar", "Espacial", "Espadachin",
+                "Familia", "Fantasia", "Gore", "Harem", "Historico", "Isekai", "Josei", "Juegos", "Magia", "Mecha",
+                "Militar", "Misterio", "Musica", "Parodia", "Psicologico", "Recuerdos", "Robots", "Romance",
+                "Samurai", "Seinen", "Shoujo", "Shounen", "Sobrenatural", "Studio+ghibli", "Superpoderes",
+                "Suspenso", "Terror", "Vampiros", "Yaoi", "Yuri", "Zombies"
+              ],
+                optionsLimit: 1, isRequired: false
+            },
+            { name: "skip", isRequired: false }
+          ]
+        },
+        {
           id: "animeflv|genres", type: "AnimeFLV", name: "AnimeFLV",
           extra: [
             {
@@ -159,6 +176,23 @@ function ReadManifest() {
           ]
         },
         {
+          id: "animejara|genres", type: "AnimeJara", name: "AnimeJara",
+          extra: [
+            {
+              name: "genre",
+              options: ["Accion", "Amor", "Artes+marciales", "Aventura", "Carreras", "Ciencia+ficcion", 
+                "Comedia", "Crimen", "Demonios", "Deportes", "Drama", "Ecchi", "Escolar", "Espacial", "Espadachin",
+                "Familia", "Fantasia", "Gore", "Harem", "Historico", "Isekai", "Josei", "Juegos", "Magia", "Mecha",
+                "Militar", "Misterio", "Musica", "Parodia", "Psicologico", "Recuerdos", "Robots", "Romance",
+                "Samurai", "Seinen", "Shoujo", "Shounen", "Sobrenatural", "Studio+ghibli", "Superpoderes",
+                "Suspenso", "Terror", "Vampiros", "Yaoi", "Yuri", "Zombies"
+              ],
+                optionsLimit: 1, isRequired: true
+            },
+            { name: "skip", isRequired: false }
+          ]
+        },
+        {
           id: "animeflv|onair", type: "AnimeFLV", name: "On Air"
         },
         {
@@ -169,6 +203,9 @@ function ReadManifest() {
         },
         {
           id: "tioanime|onair", type: "TioAnime", name: "On Air"
+        },
+        {
+          id: "animejara|onair", type: "AnimeJara", name: "On Air"
         },
         {
           type: "series",
@@ -242,12 +279,10 @@ app.get("/:config/manifest.json", (req, res) => {
   ReadManifest().then((manif) => {
     const config=new URLSearchParams(decodeURIComponent(req.params.config))
     let providers=config?.get("onAirCatalogs")?.split(',')
-    console.log(providers)
     manif.catalogs=manif.catalogs.filter((cat)=>{
       if(!cat.id.includes("onair"))return true
       else return providers.some((prov)=>cat.id.startsWith(prov))
     })
-    //console.log("Params:", decodeURIComponent(req.params[0]))
     res.header('Cache-Control', "max-age=86400, stale-while-revalidate=86400, stale-if-error=259200")
     res.json(manif);
   }).catch((err) => {

--- a/index.js
+++ b/index.js
@@ -301,7 +301,8 @@ app.listen(process.env.PORT || 3000, () => {
   const animeAV1API = require('./routes/animeav1.js')
   const henaojaraAPI = require('./routes/henaojara.js')
   const tioanimeAPI = require('./routes/tioanime.js')
-  let imports = [animeFLVAPI, animeAV1API, tioanimeAPI, henaojaraAPI]
+  const animejaraAPI = require('./routes/animejara.js')
+  let imports = [animeFLVAPI, animeAV1API, tioanimeAPI, henaojaraAPI, animejaraAPI]
   imports.forEach((api) => {
     api.UpdateAiringAnimeFile().then(() => {
       setInterval(api.UpdateAiringAnimeFile.bind(api), 86400000); //Update every 24h

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function ReadManifest() {
     let manifest = {
       "id": 'com.' + packageJSON.name.replaceAll('-', '.'),
       "version": packageJSON.version,
-      "name": "AnimeFLV, AnimeAV1, Henaojara & TioAnime",
+      "name": "TioAnimeFLVAV1Jara",
       "logo": "https://play-lh.googleusercontent.com/ZIjIwO5FJe9R1rplSd4uz54OwBxQhwDcznjljSPl2MgHaCoyF3qG6R4kRMCB40f4l2A=w256",
       "background": "https://images6.alphacoders.com/113/1135890.jpg",
       "description": packageJSON.description,
@@ -206,6 +206,7 @@ function ReadManifest() {
         "animeav1:",
         "henaojara:",
         "tioanime:",
+        "animejara:",
         "tmdb:",
         "anilist:",
         "kitsu:",

--- a/lib/streamParsing.js
+++ b/lib/streamParsing.js
@@ -1,11 +1,21 @@
-exports.GetStreamLinks = function (serviceName, serviceSlug, streamArray, onlyInternal=true) {
+exports.getServerTitle = function (serverDomain) {
+  const cleanDom = serverDomain.replace("bysesukior", "Filemoon").replace("movearnpre", "Vidhide")
+    .replace("luluvdo", "Lulustream").replace("dhcplay", "Streamwish").replace("listeamed", "Vidguard")
+    .replace("rpmvip", "RPMshare").replace("yourupload", "YourUpload").replace("mp4upload", "MP4Upload")
+    .replace("pdrain", "PDrain").replace("hls", "HLS")
+    .replace(".com", "").replace(".net", "").replace(".org", "").replace(".top", "")
+    .replace(".to", "").replace(".ac", "").replace(".sx", "").replace(".ps", "");
+  return cleanDom.charAt(0).toUpperCase() + cleanDom.slice(1)
+}
+
+exports.GetStreamLinks = function (serviceName, serviceSlug, streamArray, onlyInternal = true) {
   if (streamArray?.data?.servers === undefined) throw Error("Invalid response!")
   let epName = (streamArray.data.number) ? streamArray.data.title + " Ep. " + streamArray.data.number : streamArray.data.title
   const externalStreams = streamArray.data.servers.filter((src) => src.embed !== undefined).map((source) => {
     return {
       externalUrl: source.embed,
-      name: serviceName + "\n" + source.name + "⇗\n(external)" + ((source.dub) ? "\n🗣️🎙️(🇪🇸DUB)" : ""),
-      title: epName + "\n⚙️ (opens " + source.name + " in your browser)\n🔗 " + source.embed + ((source.dub) ? "\n🗣️🎙️(🇪🇸DUB)" : "\n🇯🇵🇪🇸"),
+      name: serviceName + "\n" + source.name + "⇗\n(external)" + ((source.dub) ? `\n🗣️🎙️(${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}DUB)` : ""),
+      title: epName + "\n⚙️ (opens " + source.name + " in your browser)\n🔗 " + source.embed + ((source.dub) ? `\n🗣️🎙️(${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}DUB)` : `\n🇯🇵${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}`),
       behaviorHints: {
         bingeGroup: serviceSlug + "|" + source.name + "|ext",
         filename: source.embed
@@ -19,8 +29,8 @@ exports.GetStreamLinks = function (serviceName, serviceSlug, streamArray, onlyIn
       return GetStreamTapeLink(source.download).then((realURL) => {
         return {
           url: realURL,
-          name: serviceName + " - " + source.name + ((source.dub) ? "\n🗣️🎙️(🇪🇸DUB)" : ""),
-          title: epName + " via " + source.name + "\n" + realURL + ((source.dub) ? "\n🗣️🎙️(🇪🇸DUB)" : "\n🇯🇵🇪🇸"),
+          name: serviceName + " - " + source.name + ((source.dub) ? `\n🗣️🎙️(${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}DUB)` : ""),
+          title: epName + " via " + source.name + "\n" + realURL + ((source.dub) ? `\n🗣️🎙️(${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}DUB)` : `\n🇯🇵${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}`),
           behaviorHints: {
             bingeGroup: serviceSlug + "|" + source.name,
             filename: realURL,
@@ -80,7 +90,7 @@ exports.GetStreamLinks = function (serviceName, serviceSlug, streamArray, onlyIn
         console.error("Failed getting Okru link:", err)
         return undefined
       })
-    } else if ((source.name === "Streamwish")||(source.name === "SW")) {
+    } else if ((source.name === "Streamwish") || (source.name === "SW")) {
       return GetStreamwishLink(source.embed).then((realURL) => {
         return FormatStream(realURL, source, epName, serviceName, serviceSlug, new URL(source.embed).hostname)
       }).catch((err) => {
@@ -104,7 +114,7 @@ exports.GetStreamLinks = function (serviceName, serviceSlug, streamArray, onlyIn
     }
   })
 
-  return Promise.allSettled(promises).then((results) =>{
+  return Promise.allSettled(promises).then((results) => {
     const internalStreams = results.filter((prom) => (prom.value)).map((source) => source.value)
     return (onlyInternal) ? internalStreams : internalStreams.concat(externalStreams)
   })
@@ -113,8 +123,8 @@ exports.GetStreamLinks = function (serviceName, serviceSlug, streamArray, onlyIn
 function FormatStream(realURL, source, epName, serviceName, serviceSlug, referer = undefined) {
   return {
     url: realURL,
-    name: serviceName + "\n" + source.name + ((source.dub) ? "\n🗣️🎙️(🇪🇸DUB)" : ""),
-    title: epName + "\n⚙️ " + source.name + "\n🔗 " + realURL + ((source.dub) ? "\n🗣️🎙️(🇪🇸DUB)" : "\n🇯🇵🇪🇸"),
+    name: serviceName + "\n" + source.name + ((source.dub) ? `\n🗣️🎙️(${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}DUB)` : ""),
+    title: epName + "\n⚙️ " + source.name + "\n🔗 " + realURL + ((source.dub) ? `\n🗣️🎙️(${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}DUB)` : `\n🇯🇵${(source.dubLang==="lat")?"🇲🇽":"🇪🇸"}`),
     behaviorHints: {
       bingeGroup: serviceSlug + "|" + source.name,
       filename: realURL,

--- a/lib/streamParsing.js
+++ b/lib/streamParsing.js
@@ -50,7 +50,7 @@ exports.GetStreamLinks = function (serviceName, serviceSlug, streamArray, onlyIn
       })
     } else if (source.name === "MP4Upload") {
       return GetMP4UploadLink(source.embed).then((realURL) => {
-        return FormatStream(realURL, source, epName, serviceName, serviceSlug, "https://a4.mp4upload.com")
+        return FormatStream(realURL, source, epName, serviceName, serviceSlug, "https://a1.mp4upload.com")
       }).catch((err) => {
         console.error("Failed getting MP4Upload link:", err)
         return undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animeflv-stremio-addon",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "animeflv-stremio-addon",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@vercel/blob": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "animeflv-stremio-addon",
-  "version": "1.2.1",
-  "description": "Add AnimeFLV, AnimeAV1, Henaojara & TioAnime functionallity to Stremio, including catalogs, streams and metadata, even showing upcoming episodes in the calendar! Not affiliated with AnimeFLV, AnimeAV1, Henaojara or TioAnime. GitHub repo: https://github.com/Pigamer37/animeflv-stremio-addon",
+  "version": "1.3.1",
+  "description": "Add AnimeFLV, AnimeAV1, Henaojara, TioAnime & AnimeJara functionallity to Stremio, including catalogs, streams and metadata, even showing upcoming episodes in the calendar! Not affiliated with AnimeFLV, AnimeAV1, Henaojara or TioAnime. GitHub repo: https://github.com/Pigamer37/animeflv-stremio-addon",
   "main": "index.js",
   "scripts": {
     "devStart": "nodemon index.js --ignore onair_titles.json --ignore onairAV1_titles.json --ignore onairHENAOJARA_titles.json --ignore onair_titlesTIO.json --ignore onairANIMEJARA_titles.json --ignore README",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "animeflv-stremio-addon",
-  "version": "1.1.0",
-  "description": "Add AnimeFLV, AnimeAV1, Henaojara & TioAnime functionallity to Stremio, including catalogs, streams and metadata, even showing upcoming episodes in the calendar! Not affiliated with AnimeFLV, AnimeAV1, Henaojara or TioAnime. GitHub repo: https://github.com/Pigamer37/animeflv-stremio-addon",
+  "version": "1.2.0",
+  "description": "Add AnimeFLV, AnimeAV1, Henaojara, TioAnime & Animejara functionallity to Stremio, including catalogs, streams and metadata, even showing upcoming episodes in the calendar! Not affiliated with AnimeFLV, AnimeAV1, Henaojara or TioAnime. GitHub repo: https://github.com/Pigamer37/animeflv-stremio-addon",
   "main": "index.js",
   "scripts": {
-    "devStart": "nodemon index.js --ignore onair_titles.json --ignore onairAV1_titles.json --ignore onairHENAOJARA_titles.json --ignore onair_titlesTIO.json --ignore README",
-    "devStartApp": "nodemon index.js --ignore onair_titles.json --ignore onairAV1_titles.json --ignore onairHENAOJARA_titles.json --ignore onair_titlesTIO.json --ignore README --launch",
-    "devStartWeb": "nodemon index.js --ignore onair_titles.json --ignore onairAV1_titles.json --ignore onairHENAOJARA_titles.json --ignore onair_titlesTIO.json --ignore README --webLaunch",
+    "devStart": "nodemon index.js --ignore onair_titles.json --ignore onairAV1_titles.json --ignore onairHENAOJARA_titles.json --ignore onair_titlesTIO.json --ignore onairANIMEJARA_titles.json --ignore README",
+    "devStartApp": "nodemon index.js --ignore onair_titles.json --ignore onairAV1_titles.json --ignore onairHENAOJARA_titles.json --ignore onair_titlesTIO.json --ignore onairANIMEJARA_titles.json --ignore README --launch",
+    "devStartWeb": "nodemon index.js --ignore onair_titles.json --ignore onairAV1_titles.json --ignore onairHENAOJARA_titles.json --ignore onair_titlesTIO.json --ignore onairANIMEJARA_titles.json --ignore README --webLaunch",
     "start": "node index.js"
   },
   "repository": {

--- a/routes/animejara.js
+++ b/routes/animejara.js
@@ -117,7 +117,7 @@ exports.GetAnimeBySlug = async function (slug, type = "series") {
       name: data.data.title, alternative_titles: data.data.alternative_titles, type: (data.data.type === "Pelicula" || data.data.type === "Película" || data.data.type === "Especial") ? "movie" : "series",
       videos, poster: data.data.cover, /*background: ,*/ genres: data.data.genres, description: data.data.synopsis.replaceAll(/\\n/g, '\n').replaceAll(/\\"/g, '"'), website: data.data.url, id: `animejara:${slug}`,
       language: "jpn", links,
-      ...(data.data.startDate) && { released: data.data.startDate, releaseInfo: data.data.startDate.getFullYear() + "-" },
+      ...(data.data.startDate) && { released: data.data.startDate, releaseInfo: `${data.data.startDate.getFullYear()}${(data.data.status === "FINALIZADO") ? "" : "-"}` },
       ...(data.data.next_airing_episode !== undefined) && { behaviorHints: { hasScheduledVideos: true } },
       ...(videos.length == 1) && { behaviorHints: { defaultVideoId: `animejara:${slug}` } }
     }
@@ -157,6 +157,7 @@ async function GetEpisodeLinks(slug, season = undefined, epNumber = undefined) {
 
     const episodeLinks = {
       title: $("div.anime-info > h1").text() || $("div.episodio-detalle-header > h1.episodio-title").text(),
+      number: Number($("#content div.episodio-info > div.episodio-meta").text().match(/Episodio (\d+)/)?.[1]),
       servers: []
     }
 
@@ -175,7 +176,7 @@ async function GetEpisodeLinks(slug, season = undefined, epNumber = undefined) {
           if (idioma.find(".lang-name").text().includes("CAS")) espI = { url: new URL(e), dubLang: "esp" }
         }
       })
-    } catch(error) {
+    } catch (error) {
       return null
     }
 
@@ -207,18 +208,18 @@ async function GetEpisodeLinks(slug, season = undefined, epNumber = undefined) {
     let servers = [];
 
     const promises = [japI, latI, espI].map((e) => {
-      if(!e) return undefined
+      if (!e) return undefined
       async function lel(e1) {
         const $2 = cheerio.load(await serverData(e1.url));
         if ($2) {
           const lis = $2("#logo-list > li");
           lis.each((_, el) => {
             let match = $(el).attr('onclick')?.match(/playVideo\(&quot;(.*?)&quot/)?.[1]?.trim()
-            if(!match) match = $(el).attr('onclick')?.match(/playVideo\("(.*?)"/)?.[1]?.trim()
+            if (!match) match = $(el).attr('onclick')?.match(/playVideo\("(.*?)"/)?.[1]?.trim()
             const sURL = new URL(match);
             servers.push({
               title: streamParser.getServerTitle($(el).find('.nombre-server')?.text() || sURL.hostname),
-              code: sURL.toString().replace("https://nyuu.streamhj.top/player/e/v/go.php?v=",""),
+              code: sURL.toString().replace("https://nyuu.streamhj.top/player/e/v/go.php?v=", ""),
               dub: e1.dubLang !== 'jap',
               dubLang: e1.dubLang
             });
@@ -366,10 +367,10 @@ async function SearchAnimesBySpecificURL(animejaraURL) {
       else foundPages = Number(aTagValue);
 
       if (aRef.text() === "1" || foundPages == 1) previousPage = null;
-      else previousPage = animejaraURL.replace(/&paged=\d+/,"")+`&paged=${aRef.attr('data-page')}`;
+      else previousPage = animejaraURL.replace(/&paged=\d+/, "") + `&paged=${aRef.attr('data-page')}`;
 
       if (!selector.last().children("a").text().includes("Último") || foundPages == 1) nextPage = null;
-      else nextPage = animejaraURL.replace(/&paged=\d+/,"")+`&paged=${selector.last().find("a").attr('data-page')}`;
+      else nextPage = animejaraURL.replace(/&paged=\d+/, "") + `&paged=${selector.last().find("a").attr('data-page')}`;
 
       return { foundPages, nextPage, previousPage };
     }
@@ -384,7 +385,7 @@ async function SearchAnimesBySpecificURL(animejaraURL) {
           let dataAnime
           try {
             dataAnime = JSON.parse($(el).find("a.anime-card").attr('data-anime'))
-          } catch (error) {}
+          } catch (error) { }
           mediaVec.push({
             title: $(el).find("h3").text() || dataAnime?.titulo,
             cover: $(el).find("a > div > div.card-poster-wrapper > img").attr("src") || dataAnime?.poster,

--- a/routes/animejara.js
+++ b/routes/animejara.js
@@ -38,13 +38,13 @@ exports.UpdateAiringAnimeFile = function () {
   return this.GetAiringAnimeFromWeb().then((titles) => {
     console.log(`\x1b[36mGot ${titles.length} titles\x1b[39m, saving to cache`)
     return fsPromises.writeFile('./onairANIMEJARA_titles.json', JSON.stringify(titles))
-  }).then(() => console.log('\x1b[32mOn Air Animejara titles "cached" successfully!\x1b[39m')
+  }).then(() => console.log('\x1b[32mOn Air AnimeJara titles "cached" successfully!\x1b[39m')
   ).catch((err) => {
     console.error('\x1b[31mFailed "caching" titles:\x1b[39m ' + err)
   })
 }
 
-exports.SearchAnimejara = async function (query, type = undefined, genreArr = undefined, url = undefined, page = undefined, gottenItems = 0) {
+exports.SearchAnimeJara = async function (query, type = undefined, genreArr = undefined, url = undefined, page = undefined, gottenItems = 0) {
   if (!url && !query && !genreArr) throw Error("No arguments passed to SearchAnimejara()")
   if (type) {
     type = (type === "movie") ? "tipo%3Dpelicula%26" : "tipo%3Dserie%26"
@@ -52,7 +52,7 @@ exports.SearchAnimejara = async function (query, type = undefined, genreArr = un
   const animejaraURL = (url) ? url
     : `${encodeURIComponent(ANIMEJARA_BASE)}%2Fcatalogo%3F${(query) ? "q%3D" + encodeURIComponent(query) + "%26" : ""}${(type) ? type : ""}${(genreArr) ? encodeURIComponent("tag%3D" + genreArr.join("%2C")) : ""}${(page) ? "%26paged%3D" + page : ""}`
   console.log("Animejara Search URL:", animejaraURL)
-    return SearchAnimesBySpecificURL(animejaraURL).then((data) => {
+  return SearchAnimesBySpecificURL(animejaraURL).then((data) => {
     if (!data) throw Error("Invalid response!")
     return { data }
   }).then((data) => {
@@ -61,14 +61,14 @@ exports.SearchAnimejara = async function (query, type = undefined, genreArr = un
     return data.data.media.slice(gottenItems).map((anime) => {
       return {
         title: anime.title, type: (anime.type === "Pelicula" || anime.type === "Película" || anime.type === "Especial" || anime.type === "movie") ? "movie" : "series",
-        slug: anime.slug, poster: anime.cover, overview: anime.synopsis, genres: genreArr
+        slug: anime.slug, poster: anime.cover, overview: anime.synopsis, genres: anime.genres || genreArr
       }
     })
   })
 }
 
-exports.GetAnimeBySlug = async function (slug) {
-  return GetAnimeInfo(slug).then((data) => {
+exports.GetAnimeBySlug = async function (slug, type = "series") {
+  return GetAnimeInfo(slug, type).then((data) => {
     if (!data) throw Error("Invalid response!")
     return { data }
   }).then((data) => {
@@ -78,24 +78,26 @@ exports.GetAnimeBySlug = async function (slug) {
     const videos = data.data.episodes.map((ep) => {
       let d = new Date(Date.now())
       return {
-        id: `animejara:${slug}:${ep.number}`,
-        title: data.data.title + " Ep. " + ep.number,
-        season: 1,
+        id: `animejara:${slug}${(ep.season) ? `:${ep.season}:${ep.number}` : ""}`,//animejara:konosuba:1:2
+        title: ep.name || data.data.title + " Ep. " + ep.number,
+        season: ep.season,
         episode: ep.number,
         number: ep.number,
-        thumbnail: data.data.cover,
+        thumbnail: ep.poster || data.data.cover,
         released: new Date(d.setDate(d.getDate() - (epCount - ep.number))),
         available: true
       }
     })
     if (data.data.next_airing_episode !== undefined) {
+      const lastS = Number(data.data.episodes[epCount - 1].season)
+      const lastNum = Number(data.data.episodes[epCount - 1].number)
       videos.push({
-        id: `animejara:${slug}:${epCount + 1}`,
-        title: `${data.data.title} Ep. ${epCount + 1}`,
-        season: 1,
-        episode: epCount + 1,
-        number: epCount + 1,
-        thumbnail: "https://www3.animeflv.net/assets/animeflv/img/cnt/proximo.png",
+        id: `animejara:${slug}:${lastS}:${lastNum + 1}`,
+        title: `${data.data.title} Ep. ${lastNum + 1}`,
+        season: lastS,
+        episode: lastNum + 1,
+        number: lastNum + 1,
+        thumbnail: "https://imgur.com/3U6r1nF",
         released: new Date(data.data.next_airing_episode),
         available: false //next episode is not available yet
       })
@@ -103,43 +105,46 @@ exports.GetAnimeBySlug = async function (slug) {
     if (videos.length === 1 && epCount === 1) { //If only one ep. probably a movie, remove the "Ep. 1" from the title
       videos[0].title = videos[0].title.replace(" Ep. 1", "")
     }
-    return {
-      name: data.data.title, alternative_titles: data.data.alternative_titles, type: (data.data.type === "Pelicula" || data.data.type === "Película" || data.data.type === "Especial") ? "movie" : "series",
-      videos, poster: data.data.cover, /*background: ,*/ genres: data.data.genres, description: data.data.synopsis.replaceAll(/\\n/g,'\n').replaceAll(/\\"/g,'"'), website: data.data.url, id: `animejara:${slug}`,
-      language: "jpn", ...(data.data.related) && {
-        links: data.data.related.map((r) => {
+    links = [{ name: "AnimeJara", category: "Open in", url: data.data.url }, { name: data.data.title, category: "share", url: data.data.url }]
+    if (data.data.related) {//Add relation links if they exist
+      links.push(
+        ...data.data.related.map((r) => {
           return { name: r.title, category: r.relation, url: `stremio:///detail/series/animejara:${r.slug}` }
         })
-      },
+      )
+    }
+    return {
+      name: data.data.title, alternative_titles: data.data.alternative_titles, type: (data.data.type === "Pelicula" || data.data.type === "Película" || data.data.type === "Especial") ? "movie" : "series",
+      videos, poster: data.data.cover, /*background: ,*/ genres: data.data.genres, description: data.data.synopsis.replaceAll(/\\n/g, '\n').replaceAll(/\\"/g, '"'), website: data.data.url, id: `animejara:${slug}`,
+      language: "jpn", links,
       ...(data.data.startDate) && { released: data.data.startDate, releaseInfo: data.data.startDate.getFullYear() + "-" },
       ...(data.data.next_airing_episode !== undefined) && { behaviorHints: { hasScheduledVideos: true } },
-      ...(videos.length == 1) && { behaviorHints: { defaultVideoId: `animejara:${slug}:1` } }
+      ...(videos.length == 1) && { behaviorHints: { defaultVideoId: `animejara:${slug}` } }
     }
   })
 }
 //WIP
-exports.GetItemStreams = async function (slug, epNumber = 1) {
-  //if we don't get an episode number, use 1, that's how animejara works
-  return GetEpisodeLinks(slug, epNumber).then((data) => {
+exports.GetItemStreams = async function (slug, onlyInternal = true, season = undefined, epNumber = undefined) {
+  return GetEpisodeLinks(slug, season, epNumber).then((data) => {
     if (!data) throw Error('Empty response!')
     return { data }
   }).then((data) => {
-    return streamParser.GetStreamLinks("Animejara", "animejara", data)
+    return streamParser.GetStreamLinks("AnimeJara", "animejara", data, onlyInternal)
   })
 }
 
-async function GetEpisodeLinks(slug, epNumber = 1) {
+async function GetEpisodeLinks(slug, season = undefined, epNumber = undefined) {
   try {
     const episodeData = async () => {
-      if (slug && !epNumber)
-        return await fetch(ANIMEJARA_BASE + "/movie/" + slug).then((resp) => {
-          if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+      if (slug && !season)
+        return await fetch(`${ANIMEJARA_BASE}/movie/${slug}`).then((resp) => {
+          //if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`) //AnimeJara throws 404s
           if (resp === undefined) throw Error(`Undefined response!`)
           return resp.text()
         }).catch(() => null);
-      else if (slug && epNumber)
-        return await fetch(ANIMEJARA_BASE + "/episode/" + slug + "-" + epNumber).then((resp) => {
-          if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+      else if (slug && season)
+        return await fetch(`${ANIMEJARA_BASE}/episode/${slug}-${season}x${epNumber}`).then((resp) => {
+          //if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
           if (resp === undefined) throw Error(`Undefined response!`)
           return resp.text()
         }).catch(() => null);
@@ -156,57 +161,85 @@ async function GetEpisodeLinks(slug, epNumber = 1) {
     }
 
     const serversDIV = $("div.botones-idioma > div.boton-idioma"); //may be 1-3 (LATINO, JAPONÉS, CASTELLANO)
-    
-    const serversObj = serversDIV.filter((_, el) => $(el).find(".lang-name").text().includes("JAP"));
-    const downloadObj = metadataJSON?.match(/downloads:\s?.*?SUB:\s?(\[.*?\])/)?.[1];
-    const serversObjDUB = serversDIV.filter((_, el) => !$(el).find(".lang-name").text().includes("JAP"));
-    const downloadObjDUB = metadataJSON?.match(/downloads:\s?.*?DUB:\s?(\[.*?\])/)?.[1];
+
+    let japI, latI, espI;
+    const episodesFind = $("script").map((_, el) => $(el).html()).get().find(script => script?.includes("const enlaces = "));
+    const enlacesArray = episodesFind?.match(/enlaces = (\[.*]);/)?.[1];
+    try {
+      const enlaces = JSON.parse(enlacesArray)
+      enlaces.forEach((e, i) => {
+        const idioma = serversDIV.filter((_, el) => $(el).attr('onclick').includes(`cambiarIdioma(${i}`)).first()
+        if (idioma) {
+          if (idioma.find(".lang-name").text().includes("JAP")) japI = { url: new URL(e), dubLang: "jap" }
+          if (idioma.find(".lang-name").text().includes("LAT")) latI = { url: new URL(e), dubLang: "lat" }
+          if (idioma.find(".lang-name").text().includes("CAS")) espI = { url: new URL(e), dubLang: "esp" }
+        }
+      })
+    } catch(error) {
+      return null
+    }
+
+    async function serverData(url) {
+      return await fetch(url, {
+        "headers": {
+          "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+          "accept-language": "en,en-US;q=0.9,es-ES;q=0.8,es;q=0.7,fr;q=0.6,no;q=0.5",
+          "cache-control": "no-cache",
+          "pragma": "no-cache",
+          "priority": "u=0, i",
+          "sec-ch-ua": "\"Chromium\";v=\"148\", \"Opera\";v=\"132\", \"Not/A)Brand\";v=\"99\"",
+          "sec-ch-ua-mobile": "?0",
+          "sec-ch-ua-platform": "\"Linux\"",
+          "sec-fetch-dest": "iframe",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-site": "cross-site",
+          "sec-fetch-storage-access": "active",
+          "upgrade-insecure-requests": "1",
+          "Referer": "https://animejara.com/"
+        },
+        "method": "GET"
+      }).then((resp) => {
+        if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+        if (resp === undefined) throw Error(`Undefined response!`)
+        return resp.text()
+      }).catch(() => { console.log("Failed to fetch server data"); return null });
+    }
     let servers = [];
-    if (serversObj) {
-      servers = serversObj.split("},")?.map(s => {
-        return {
-          title: s.match(/server:\s?"(.*?)"/)?.[1],
-          code: s.match(/url:\s?"(.*?)"/)?.[1]
-        }
-      });
-    }
-    if (downloadObj) {
-      servers = servers.concat(downloadObj.split("},")?.map(s => {
-        return {
-          title: s.match(/server:\s?"(.*?)"/)?.[1],
-          url: s.match(/url:\s?"(.*?)"/)?.[1]
-        }
-      }));
-    }
-    if (serversObjDUB) {
-      servers = servers.concat(serversObjDUB.split("},")?.map(s => {
-        return {
-          title: s.match(/server:\s?"(.*?)"/)?.[1],
-          code: s.match(/url:\s?"(.*?)"/)?.[1],
-          dub: true
-        }
-      }));
-    }
-    if (downloadObjDUB) {
-      servers = servers.concat(downloadObjDUB.split("},")?.map(s => {
-        return {
-          title: s.match(/server:\s?"(.*?)"/)?.[1],
-          url: s.match(/url:\s?"(.*?)"/)?.[1],
-          dub: true
-        }
-      }));
-    }
 
-    for (const s of servers) {
-      episodeLinks.servers.push({
-        name: s?.title,
-        download: s?.url?.replace("mega.nz/#!", "mega.nz/file/"),
-        embed: s?.code?.replace("mega.nz/embed#!", "mega.nz/embed/"),
-        dub: s?.dub || false
-      });
-    }
+    const promises = [japI, latI, espI].map((e) => {
+      if(!e) return undefined
+      async function lel(e1) {
+        const $2 = cheerio.load(await serverData(e1.url));
+        if ($2) {
+          const lis = $2("#logo-list > li");
+          lis.each((_, el) => {
+            let match = $(el).attr('onclick')?.match(/playVideo\(&quot;(.*?)&quot/)?.[1]?.trim()
+            if(!match) match = $(el).attr('onclick')?.match(/playVideo\("(.*?)"/)?.[1]?.trim()
+            const sURL = new URL(match);
+            servers.push({
+              title: streamParser.getServerTitle($(el).find('.nombre-server')?.text() || sURL.hostname),
+              code: sURL.toString().replace("https://nyuu.streamhj.top/player/e/v/go.php?v=",""),
+              dub: e1.dubLang !== 'jap',
+              dubLang: e1.dubLang
+            });
+          });
+        }
+      }
+      return lel(e)
+    })
 
-    return episodeLinks;
+    return Promise.allSettled(promises).then((results) => {
+      for (const s of servers) {
+        episodeLinks.servers.push({
+          name: s?.title,
+          download: s?.url?.replace("mega.nz/#!", "mega.nz/file/"),
+          embed: s?.code?.replace("mega.nz/embed#!", "mega.nz/embed/"),
+          dub: s?.dub || false,
+          dubLang: s?.dubLang
+        })
+      }
+      return episodeLinks
+    })
   } catch (e) {
     console.error("Error on GetEpisodeLinks:", e);
     throw e
@@ -225,20 +258,18 @@ async function GetAnimeInfo(slug, type = "series") {
 
     const $ = cheerio.load(html);
     const scripts = $("script");
-    const nextAiringFind = $("div.fechas-container > div.fechas-lista > div.proximo-item");
-    const nextAiringInfo = nextAiringFind?.find("span")[0]?.text().replace("LATINO", "").replace("JAPONÉS", "").replace("CASTELLANO", "").trim();
 
     const animeInfo = {
       title: $("div.anime-info > h1").text(),
       //alternative_titles: $("#l > div.info > div.info-b > h3").text().split(",") || [],
       status: $("#posterContainer > div").text(),
-      startDate: new Date($("div:stat-item > span").text()),
+      startDate: new Date($("div.stat-item > span").first().text()),
       rating: $("#rating-val").text(),
-      type: ($("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.movie-meta-row > span").text()=="PELÍCULA") ? "movie" : "series",
+      type: ($("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.movie-meta-row > span").text() == "PELÍCULA") ? "movie" : "series",
       cover: $("#mainPosterImg").attr("src"),
       synopsis: $("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.anime-sinopsis-contenedor > div").text(),
       genres: $("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.anime-categorias > span").map((_, el) => $(el).text().trim()).get(),
-      next_airing_episode: nextAiringInfo,
+      //next_airing_episode: nextAiringInfo,
       episodes: [],
       url
     };
@@ -248,56 +279,51 @@ async function GetAnimeInfo(slug, type = "series") {
         animeInfo.episodes.push({
           number: 1,
           slug: slug,
-          url: ANIMEAV1_BASE + "/movie/" + slug
+          url: ANIMEAV1_BASE + "/movie/" + slug,
+          poster: animeInfo.cover
         });
       }
     } else {
+      const nextAiringFind = $("div.fechas-container > div.fechas-lista > div.proximo-item");
+      const nextAiringInfo = nextAiringFind?.first()?.find("span")?.text().replace("LATINO", "").replace("JAPONÉS", "").replace("CASTELLANO", "").trim();
+      animeInfo.next_airing_episode = new Date(nextAiringInfo);
+
       const episodesFind = scripts.map((_, el) => $(el).html()).get().find(script => script?.includes("TEMPORADAS_DATA"));
       const episodesArray = episodesFind?.match(/TEMPORADAS_DATA = (\[.*]);/)?.[1];
 
-      const selectedSeason = $("#seasonsNav > div.active");
-      let seasonNumber = Number(selectedSeason.find("div.tab-title")?.text().replace("TEMPORADA", "").trim()) || 1;
-
-      let epCount = 0;
+      let temporadasData;
       try {
-        const epObj = JSON.parse(episodesArray)
-        if (epObj) epCount = epObj.find((season) => season.numero_temporada === seasonNumber)?.episodios.length;
+        temporadasData = JSON.parse(episodesArray)
       } catch (error) {
-        const epCountStr = selectedSeason.find("span")?.text().replace("episodios", "").trim();
+        const tempData = $("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.anime-stats-top > div")
+        const seasonCountStr = tempData?.eq(0)?.text().replace("Temporadas", "").trim();
+        if (seasonCountStr && seasonCountStr !== "") {
+          temporadasData = []
+          $("#seasonsNav > div.season-tab").get().forEach((e, i) => {
+            const seasEpCount = Number(e.find('div.tab-info > span').text().replace("episodios").trim())
+            const seasonNum = Number(e.attr('data-season')) || i + 1;
+            const seasonImg = e.find('img').attr('src');
+            let epArr = []
+            for (let ep = 1; ep < seasEpCount; ep++) { epArr.push({ numero_episodio: ep, poster_episodio: seasonImg }) }
+            temporadasData.push({ numero_temporada: seasonNum, poster_temporada: seasonImg, episodios: epArr })
+          })
+        }
+        const epCountStr = tempData?.eq(1)?.text().replace("Episodios", "").trim();
         if (epCountStr && epCountStr !== "") epCount = Number(epCountStr);
       }
-      
-      for (let i = 1; i <= epCount; i++) {
-        if (animeInfo.episodes instanceof Array) {
+
+      temporadasData?.forEach((s, si) => {
+        s.episodios?.forEach((e, ei) => {
+          const sn = s.numero_temporada || si + 1, en = e.numero_episodio || ei + 1;
           animeInfo.episodes.push({
-            number: i,
-            slug: slug + "-" + seasonNumber + "x" + i,
-            url: ANIMEAV1_BASE + "/episode/" + slug + "-" + seasonNumber + "x" + i
-          });
-        }
-      }
-
-      //Relacionados
-      const relatedEls = $("#seasonsNav > div.season-tab").not(".active");
-      const relatedAnimes = [];
-      relatedEls.each((_, el) => {
-        const title = $(el).find(".tab-title").text().trim();
-        const relation = "TEMPORADAS";//$(el).find(".tab-title").text().trim();
-        if (title) {
-          const slugi = `${slug}#season-${title.replace("TEMPORADA", "").trim()}`;
-          relatedAnimes.push({
-            title,
-            relation,
-            slug: slugi,
-            url: `${ANIMEJARA_BASE}/anime/${slugi}`
-          });
-        }
-      });
-
-      //Asigna la propiedad si hay elementos
-      if (relatedAnimes.length > 0) {
-        animeInfo.related = relatedAnimes;
-      }
+            season: sn,
+            number: en,
+            slug: `${slug}-${sn}x${en}`,
+            url: `${ANIMEJARA_BASE}/episode/${slug}-${sn}x${en}`,
+            poster: e.poster_episodio
+          })
+        })
+      })
     }
 
     return animeInfo;
@@ -325,12 +351,12 @@ async function SearchAnimesBySpecificURL(animejaraURL) {
       media: []
     };
 
-    const pageSelector = $("#m > section > ul.pag > li");
+    const pageSelector = $("#paginacion-container > ul.paginacion > li");
     const getNextAndPrevPages = (selector) => {
       let aTagValue = selector.last().prev().find("a").text();
-      if (aTagValue.includes("Siguiente")) aTagValue = selector.last().prev().prev().find("a").text();
+      if (aTagValue.includes("»")) aTagValue = selector.last().prev().prev().find("a").text();
       let aRef = selector.eq(0).children("a");
-      if (aRef.text().includes("Inicio")) aRef = selector.eq(1).children("a");
+      //if (aRef.text().includes("«")) aRef = selector.eq(1).children("a");
 
       let foundPages = 0;
       let previousPage = "";
@@ -340,29 +366,34 @@ async function SearchAnimesBySpecificURL(animejaraURL) {
       else foundPages = Number(aTagValue);
 
       if (aRef.text() === "1" || foundPages == 1) previousPage = null;
-      else previousPage = ANIMEJARA_BASE + aRef.attr("href");
+      else previousPage = animejaraURL.replace(/&paged=\d+/,"")+`&paged=${aRef.attr('data-page')}`;
 
       if (!selector.last().children("a").text().includes("Último") || foundPages == 1) nextPage = null;
-      else nextPage = ANIMEJARA_BASE + selector.last().prev().find("a").attr("href");
+      else nextPage = animejaraURL.replace(/&paged=\d+/,"")+`&paged=${selector.last().find("a").attr('data-page')}`;
 
       return { foundPages, nextPage, previousPage };
     }
     const { foundPages, nextPage, previousPage } = getNextAndPrevPages(pageSelector)
     const scrapSearchAnimeData = ($) => {
-      const selectedElement = $("#m > section > div > article");
+      const selectedElement = $("#anime-results > div.anime-card-wrapper");
 
       if (selectedElement.length > 0) {
         const mediaVec = [];
 
         selectedElement.each((_, el) => {
+          let dataAnime
+          try {
+            dataAnime = JSON.parse($(el).find("a.anime-card").attr('data-anime'))
+          } catch (error) {}
           mediaVec.push({
-            title: $(el).find("h3").text() || $(el).find("figure > a > img").attr("alt"),
-            cover: $(el).find("figure > a > img").attr("data-src"),
-            //synopsis: $(el).find("div > div > div > p").eq(1).text(),
-            //rating: $(el).find("article > div > p:nth-child(2) > span.Vts.fa-star").text(),
-            slug: $(el).find("a").attr("href").replace("./anime/", ""),
-            type: $(el).find("figure > a > b").text(),
-            url: ANIMEJARA_BASE + ($(el).find("a").attr("href").replace('.', '') || $(el).find("h3 > a").attr("href").replace('.', '')),
+            title: $(el).find("h3").text() || dataAnime?.titulo,
+            cover: $(el).find("a > div > div.card-poster-wrapper > img").attr("src") || dataAnime?.poster,
+            synopsis: dataAnime?.sinopsis,
+            genres: dataAnime?.categorias,
+            rating: $(el).find("a > div > div.card-poster-wrapper div.card-rating-year > span.card-rating").text().trim() || dataAnime?.rating,
+            slug: $(el).find("a").attr("href").match(/\/([^\/]*)(?:\/)?$/)?.[1],
+            type: $(el).find("a > div > div.card-poster-wrapper div.card-meta > span.meta-type").text() || dataAnime?.tipo,
+            url: $(el).find("a").attr("href"),
           });
         });
         return mediaVec
@@ -390,14 +421,15 @@ async function SearchAnimesBySpecificURL(animejaraURL) {
 }
 
 async function GetOnAir() {
-  return SearchAnimesBySpecificURL(`${decodeURIComponent(ANIMEJARA_BASE)}/inicio`).then((data) => {
+  return SearchAnimesBySpecificURL(`${decodeURIComponent(ANIMEJARA_BASE)}/catalogo?estado=Emision`).then((data) => {
     if (!data || data.media === undefined) throw Error("Invalid response!")
     return data.media.map((anime) => {
       return {
         title: anime.title,
         type: anime.type,
         slug: anime.slug,
-        url: anime.url
+        url: anime.url,
+        genres: anime.genres
       }
     })
   })

--- a/routes/animejara.js
+++ b/routes/animejara.js
@@ -97,7 +97,7 @@ exports.GetAnimeBySlug = async function (slug, type = "series") {
         season: lastS,
         episode: lastNum + 1,
         number: lastNum + 1,
-        thumbnail: "https://imgur.com/3U6r1nF",
+        thumbnail: "https://i.imgur.com/3U6r1nF.jpg",
         released: new Date(data.data.next_airing_episode),
         available: false //next episode is not available yet
       })

--- a/routes/animejara.js
+++ b/routes/animejara.js
@@ -132,13 +132,13 @@ async function GetEpisodeLinks(slug, epNumber = 1) {
   try {
     const episodeData = async () => {
       if (slug && !epNumber)
-        return await fetch(ANIMEJARA_BASE + "/ver/" + slug).then((resp) => {
+        return await fetch(ANIMEJARA_BASE + "/movie/" + slug).then((resp) => {
           if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
           if (resp === undefined) throw Error(`Undefined response!`)
           return resp.text()
         }).catch(() => null);
       else if (slug && epNumber)
-        return await fetch(ANIMEJARA_BASE + "/ver/" + slug + "-" + epNumber).then((resp) => {
+        return await fetch(ANIMEJARA_BASE + "/episode/" + slug + "-" + epNumber).then((resp) => {
           if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
           if (resp === undefined) throw Error(`Undefined response!`)
           return resp.text()
@@ -151,71 +151,59 @@ async function GetEpisodeLinks(slug, epNumber = 1) {
     const $ = cheerio.load(await episodeData());
 
     const episodeLinks = {
-      title: $("#l > div > h1").text(),
+      title: $("div.anime-info > h1").text() || $("div.episodio-detalle-header > h1.episodio-title").text(),
       servers: []
     }
 
-    const serversDIV = $("div.dwn");
+    const serversDIV = $("div.botones-idioma > div.boton-idioma"); //may be 1-3 (LATINO, JAPONÉS, CASTELLANO)
     
-    const downloadObj = JSON.parse(serversDIV.attr("data-dwn") || "null");
-
-    const getServerTitle = (serverDomain) => {
-      const cleanDom = serverDomain.replace("bysesukior", "Filemoon").replace("movearnpre", "Vidhide")
-        .replace("luluvdo", "Lulustream").replace("dhcplay", "Streamwish").replace("listeamed", "Vidguard")
-        .replace("rpmvip", "RPMshare").replace("yourupload", "YourUpload").replace("mp4upload", "MP4Upload")
-        .replace("pdrain", "PDrain").replace("hls", "HLS")
-        .replace(".com", "").replace(".net", "").replace(".org", "").replace(".top", "")
-        .replace(".to", "").replace(".ac", "").replace(".sx", "").replace(".ps", "");
-      return cleanDom.charAt(0).toUpperCase() + cleanDom.slice(1)
-    }
-    const hex2a = (hex) => { var str = ''; for (var i = 0; i < hex.length; i += 2) str += String.fromCharCode(parseInt(hex.substr(i, 2), 16)); return str;};
-    const serverData = async () => {
-      return await fetch(`${ANIMEJARA_BASE}/hj`, {
-        "headers": {
-          "accept": "*/*",
-          "accept-language": "en,en-US;q=0.9,es-ES;q=0.8,es;q=0.7,fr;q=0.6,no;q=0.5",
-          "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-          "priority": "u=1, i",
-          "sec-ch-ua": "\"Opera GX\";v=\"125\", \"Not?A_Brand\";v=\"8\", \"Chromium\";v=\"141\"",
-          "sec-ch-ua-mobile": "?0",
-          "sec-ch-ua-platform": "\"Windows\"",
-          "sec-fetch-dest": "empty",
-          "sec-fetch-mode": "cors",
-          "sec-fetch-site": "same-origin",
-          "x-requested-with": "XMLHttpRequest",
-          "Referer": `${ANIMEJARA_BASE}/ver/${slug}-${epNumber}`,
-        },
-        "body": `acc=opt&i=${$(".opt").attr("data-encrypt")}`,
-        "method": "POST"
-      }).then((resp) => {
-        if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
-        if (resp === undefined) throw Error(`Undefined response!`)
-        return resp.text()
-      }).catch(() => {console.log("Failed to fetch server data"); return null});
-    }
-    const $2 = cheerio.load(await serverData());
-    
-    if ($2) {
-      const lis = $2("li");
-      lis.each((_, el) => {
-        const s = hex2a($(el).attr("encrypt"));
-        const sURL = new URL(s)
-        episodeLinks.servers.push({
-          name: getServerTitle(sURL.hostname),
-          embed: s?.replace("mega.nz/embed#!", "mega.nz/embed/"),
-          dub: false
-        });
+    const serversObj = serversDIV.filter((_, el) => $(el).find(".lang-name").text().includes("JAP"));
+    const downloadObj = metadataJSON?.match(/downloads:\s?.*?SUB:\s?(\[.*?\])/)?.[1];
+    const serversObjDUB = serversDIV.filter((_, el) => !$(el).find(".lang-name").text().includes("JAP"));
+    const downloadObjDUB = metadataJSON?.match(/downloads:\s?.*?DUB:\s?(\[.*?\])/)?.[1];
+    let servers = [];
+    if (serversObj) {
+      servers = serversObj.split("},")?.map(s => {
+        return {
+          title: s.match(/server:\s?"(.*?)"/)?.[1],
+          code: s.match(/url:\s?"(.*?)"/)?.[1]
+        }
       });
     }
     if (downloadObj) {
-      for (const s of downloadObj) {
-        const sURL = new URL(s)
-        episodeLinks.servers.push({
-          name: getServerTitle(sURL.hostname),
-          download: s?.replace("mega.nz/#!", "mega.nz/file/"),
-          dub: false
-        });
-      }
+      servers = servers.concat(downloadObj.split("},")?.map(s => {
+        return {
+          title: s.match(/server:\s?"(.*?)"/)?.[1],
+          url: s.match(/url:\s?"(.*?)"/)?.[1]
+        }
+      }));
+    }
+    if (serversObjDUB) {
+      servers = servers.concat(serversObjDUB.split("},")?.map(s => {
+        return {
+          title: s.match(/server:\s?"(.*?)"/)?.[1],
+          code: s.match(/url:\s?"(.*?)"/)?.[1],
+          dub: true
+        }
+      }));
+    }
+    if (downloadObjDUB) {
+      servers = servers.concat(downloadObjDUB.split("},")?.map(s => {
+        return {
+          title: s.match(/server:\s?"(.*?)"/)?.[1],
+          url: s.match(/url:\s?"(.*?)"/)?.[1],
+          dub: true
+        }
+      }));
+    }
+
+    for (const s of servers) {
+      episodeLinks.servers.push({
+        name: s?.title,
+        download: s?.url?.replace("mega.nz/#!", "mega.nz/file/"),
+        embed: s?.code?.replace("mega.nz/embed#!", "mega.nz/embed/"),
+        dub: s?.dub || false
+      });
     }
 
     return episodeLinks;

--- a/routes/animejara.js
+++ b/routes/animejara.js
@@ -1,0 +1,416 @@
+const ANIMEJARA_BASE = "https://animejara.com"
+
+const fsPromises = require("fs/promises");
+const cheerio = require("cheerio");
+const streamParser = require("../lib/streamParsing.js");
+//const vercelBlob = require("@vercel/blob");
+require('dotenv').config()//process.env.var
+
+exports.GetAiringAnimeFromWeb = async function () {
+  return GetOnAir().then((data) => {
+    if (!data || data.length < 1) throw Error("Invalid response!")
+    return { data }
+  }).then((data) => {
+    if (data?.data === undefined) throw Error("Invalid response!")
+    const promises = data.data.map((entry) => {
+      return this.GetAnimeBySlug(entry.slug).then((anime) => {
+        return {
+          title: anime.name, type: (anime.type === "Pelicula" || anime.type === "Película" || anime.type === "Especial" || anime.type === "movie") ? "movie" : "series",
+          slug: entry.slug, poster: anime.poster, overview: anime.description
+        }
+      })
+    })
+
+    return Promise.allSettled(promises).then((results) =>
+      results.filter((prom) => (prom.value)).map((source) => source.value)
+    )
+  })
+}
+
+exports.GetAiringAnime = async function () {
+  return fsPromises.readFile('./onairANIMEJARA_titles.json').then((data) => JSON.parse(data)).catch((err) => {
+    console.error('\x1b[31mFailed reading titles cache:\x1b[39m ' + err)
+    return this.GetAiringAnimeFromWeb() //If the file doesn't exist, get the titles from the web
+  })
+}
+
+exports.UpdateAiringAnimeFile = function () {
+  return this.GetAiringAnimeFromWeb().then((titles) => {
+    console.log(`\x1b[36mGot ${titles.length} titles\x1b[39m, saving to cache`)
+    return fsPromises.writeFile('./onairANIMEJARA_titles.json', JSON.stringify(titles))
+  }).then(() => console.log('\x1b[32mOn Air Animejara titles "cached" successfully!\x1b[39m')
+  ).catch((err) => {
+    console.error('\x1b[31mFailed "caching" titles:\x1b[39m ' + err)
+  })
+}
+
+exports.SearchAnimejara = async function (query, type = undefined, genreArr = undefined, url = undefined, page = undefined, gottenItems = 0) {
+  if (!url && !query && !genreArr) throw Error("No arguments passed to SearchAnimejara()")
+  if (type) {
+    type = (type === "movie") ? "tipo%3Dpelicula%26" : "tipo%3Dserie%26"
+  }
+  const animejaraURL = (url) ? url
+    : `${encodeURIComponent(ANIMEJARA_BASE)}%2Fcatalogo%3F${(query) ? "q%3D" + encodeURIComponent(query) + "%26" : ""}${(type) ? type : ""}${(genreArr) ? encodeURIComponent("tag%3D" + genreArr.join("%2C")) : ""}${(page) ? "%26paged%3D" + page : ""}`
+  console.log("Animejara Search URL:", animejaraURL)
+    return SearchAnimesBySpecificURL(animejaraURL).then((data) => {
+    if (!data) throw Error("Invalid response!")
+    return { data }
+  }).then((data) => {
+    if (data?.data?.media === undefined) throw Error("Invalid response!")
+    if (data.data.media.length < 1) throw Error("No search results!")
+    return data.data.media.slice(gottenItems).map((anime) => {
+      return {
+        title: anime.title, type: (anime.type === "Pelicula" || anime.type === "Película" || anime.type === "Especial" || anime.type === "movie") ? "movie" : "series",
+        slug: anime.slug, poster: anime.cover, overview: anime.synopsis, genres: genreArr
+      }
+    })
+  })
+}
+
+exports.GetAnimeBySlug = async function (slug) {
+  return GetAnimeInfo(slug).then((data) => {
+    if (!data) throw Error("Invalid response!")
+    return { data }
+  }).then((data) => {
+    if (data?.data === undefined) throw Error("Invalid response!")
+    //return first result
+    const epCount = data.data.episodes.length
+    const videos = data.data.episodes.map((ep) => {
+      let d = new Date(Date.now())
+      return {
+        id: `animejara:${slug}:${ep.number}`,
+        title: data.data.title + " Ep. " + ep.number,
+        season: 1,
+        episode: ep.number,
+        number: ep.number,
+        thumbnail: data.data.cover,
+        released: new Date(d.setDate(d.getDate() - (epCount - ep.number))),
+        available: true
+      }
+    })
+    if (data.data.next_airing_episode !== undefined) {
+      videos.push({
+        id: `animejara:${slug}:${epCount + 1}`,
+        title: `${data.data.title} Ep. ${epCount + 1}`,
+        season: 1,
+        episode: epCount + 1,
+        number: epCount + 1,
+        thumbnail: "https://www3.animeflv.net/assets/animeflv/img/cnt/proximo.png",
+        released: new Date(data.data.next_airing_episode),
+        available: false //next episode is not available yet
+      })
+    }
+    if (videos.length === 1 && epCount === 1) { //If only one ep. probably a movie, remove the "Ep. 1" from the title
+      videos[0].title = videos[0].title.replace(" Ep. 1", "")
+    }
+    return {
+      name: data.data.title, alternative_titles: data.data.alternative_titles, type: (data.data.type === "Pelicula" || data.data.type === "Película" || data.data.type === "Especial") ? "movie" : "series",
+      videos, poster: data.data.cover, /*background: ,*/ genres: data.data.genres, description: data.data.synopsis.replaceAll(/\\n/g,'\n').replaceAll(/\\"/g,'"'), website: data.data.url, id: `animejara:${slug}`,
+      language: "jpn", ...(data.data.related) && {
+        links: data.data.related.map((r) => {
+          return { name: r.title, category: r.relation, url: `stremio:///detail/series/animejara:${r.slug}` }
+        })
+      },
+      ...(data.data.startDate) && { released: data.data.startDate, releaseInfo: data.data.startDate.getFullYear() + "-" },
+      ...(data.data.next_airing_episode !== undefined) && { behaviorHints: { hasScheduledVideos: true } },
+      ...(videos.length == 1) && { behaviorHints: { defaultVideoId: `animejara:${slug}:1` } }
+    }
+  })
+}
+//WIP
+exports.GetItemStreams = async function (slug, epNumber = 1) {
+  //if we don't get an episode number, use 1, that's how animejara works
+  return GetEpisodeLinks(slug, epNumber).then((data) => {
+    if (!data) throw Error('Empty response!')
+    return { data }
+  }).then((data) => {
+    return streamParser.GetStreamLinks("Animejara", "animejara", data)
+  })
+}
+
+async function GetEpisodeLinks(slug, epNumber = 1) {
+  try {
+    const episodeData = async () => {
+      if (slug && !epNumber)
+        return await fetch(ANIMEJARA_BASE + "/ver/" + slug).then((resp) => {
+          if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+          if (resp === undefined) throw Error(`Undefined response!`)
+          return resp.text()
+        }).catch(() => null);
+      else if (slug && epNumber)
+        return await fetch(ANIMEJARA_BASE + "/ver/" + slug + "-" + epNumber).then((resp) => {
+          if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+          if (resp === undefined) throw Error(`Undefined response!`)
+          return resp.text()
+        }).catch(() => null);
+      else return null;
+    }
+
+    if (!(await episodeData())) return null;
+
+    const $ = cheerio.load(await episodeData());
+
+    const episodeLinks = {
+      title: $("#l > div > h1").text(),
+      servers: []
+    }
+
+    const serversDIV = $("div.dwn");
+    
+    const downloadObj = JSON.parse(serversDIV.attr("data-dwn") || "null");
+
+    const getServerTitle = (serverDomain) => {
+      const cleanDom = serverDomain.replace("bysesukior", "Filemoon").replace("movearnpre", "Vidhide")
+        .replace("luluvdo", "Lulustream").replace("dhcplay", "Streamwish").replace("listeamed", "Vidguard")
+        .replace("rpmvip", "RPMshare").replace("yourupload", "YourUpload").replace("mp4upload", "MP4Upload")
+        .replace("pdrain", "PDrain").replace("hls", "HLS")
+        .replace(".com", "").replace(".net", "").replace(".org", "").replace(".top", "")
+        .replace(".to", "").replace(".ac", "").replace(".sx", "").replace(".ps", "");
+      return cleanDom.charAt(0).toUpperCase() + cleanDom.slice(1)
+    }
+    const hex2a = (hex) => { var str = ''; for (var i = 0; i < hex.length; i += 2) str += String.fromCharCode(parseInt(hex.substr(i, 2), 16)); return str;};
+    const serverData = async () => {
+      return await fetch(`${ANIMEJARA_BASE}/hj`, {
+        "headers": {
+          "accept": "*/*",
+          "accept-language": "en,en-US;q=0.9,es-ES;q=0.8,es;q=0.7,fr;q=0.6,no;q=0.5",
+          "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+          "priority": "u=1, i",
+          "sec-ch-ua": "\"Opera GX\";v=\"125\", \"Not?A_Brand\";v=\"8\", \"Chromium\";v=\"141\"",
+          "sec-ch-ua-mobile": "?0",
+          "sec-ch-ua-platform": "\"Windows\"",
+          "sec-fetch-dest": "empty",
+          "sec-fetch-mode": "cors",
+          "sec-fetch-site": "same-origin",
+          "x-requested-with": "XMLHttpRequest",
+          "Referer": `${ANIMEJARA_BASE}/ver/${slug}-${epNumber}`,
+        },
+        "body": `acc=opt&i=${$(".opt").attr("data-encrypt")}`,
+        "method": "POST"
+      }).then((resp) => {
+        if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+        if (resp === undefined) throw Error(`Undefined response!`)
+        return resp.text()
+      }).catch(() => {console.log("Failed to fetch server data"); return null});
+    }
+    const $2 = cheerio.load(await serverData());
+    
+    if ($2) {
+      const lis = $2("li");
+      lis.each((_, el) => {
+        const s = hex2a($(el).attr("encrypt"));
+        const sURL = new URL(s)
+        episodeLinks.servers.push({
+          name: getServerTitle(sURL.hostname),
+          embed: s?.replace("mega.nz/embed#!", "mega.nz/embed/"),
+          dub: false
+        });
+      });
+    }
+    if (downloadObj) {
+      for (const s of downloadObj) {
+        const sURL = new URL(s)
+        episodeLinks.servers.push({
+          name: getServerTitle(sURL.hostname),
+          download: s?.replace("mega.nz/#!", "mega.nz/file/"),
+          dub: false
+        });
+      }
+    }
+
+    return episodeLinks;
+  } catch (e) {
+    console.error("Error on GetEpisodeLinks:", e);
+    throw e
+  }
+}
+
+async function GetAnimeInfo(slug, type = "series") {
+  try {
+    const url = (type === "series") ? `${ANIMEJARA_BASE}/anime/${slug}` : `${ANIMEJARA_BASE}/movie/${slug}`;
+    const html = await fetch(url).then((resp) => {
+      if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+      if (resp === undefined) throw Error(`Undefined response!`)
+      return resp.text()
+    })
+    if (!html) return null;
+
+    const $ = cheerio.load(html);
+    const scripts = $("script");
+    const nextAiringFind = $("div.fechas-container > div.fechas-lista > div.proximo-item");
+    const nextAiringInfo = nextAiringFind?.find("span")[0]?.text().replace("LATINO", "").replace("JAPONÉS", "").replace("CASTELLANO", "").trim();
+
+    const animeInfo = {
+      title: $("div.anime-info > h1").text(),
+      //alternative_titles: $("#l > div.info > div.info-b > h3").text().split(",") || [],
+      status: $("#posterContainer > div").text(),
+      startDate: new Date($("div:stat-item > span").text()),
+      rating: $("#rating-val").text(),
+      type: ($("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.movie-meta-row > span").text()=="PELÍCULA") ? "movie" : "series",
+      cover: $("#mainPosterImg").attr("src"),
+      synopsis: $("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.anime-sinopsis-contenedor > div").text(),
+      genres: $("#content > div > div.main-content > div > div.anime-detalle-contenedor > div > div.anime-info > div.anime-categorias > span").map((_, el) => $(el).text().trim()).get(),
+      next_airing_episode: nextAiringInfo,
+      episodes: [],
+      url
+    };
+
+    if (type === "movie") {
+      if (animeInfo.episodes instanceof Array) {
+        animeInfo.episodes.push({
+          number: 1,
+          slug: slug,
+          url: ANIMEAV1_BASE + "/movie/" + slug
+        });
+      }
+    } else {
+      const episodesFind = scripts.map((_, el) => $(el).html()).get().find(script => script?.includes("TEMPORADAS_DATA"));
+      const episodesArray = episodesFind?.match(/TEMPORADAS_DATA = (\[.*]);/)?.[1];
+
+      const selectedSeason = $("#seasonsNav > div.active");
+      let seasonNumber = Number(selectedSeason.find("div.tab-title")?.text().replace("TEMPORADA", "").trim()) || 1;
+
+      let epCount = 0;
+      try {
+        const epObj = JSON.parse(episodesArray)
+        if (epObj) epCount = epObj.find((season) => season.numero_temporada === seasonNumber)?.episodios.length;
+      } catch (error) {
+        const epCountStr = selectedSeason.find("span")?.text().replace("episodios", "").trim();
+        if (epCountStr && epCountStr !== "") epCount = Number(epCountStr);
+      }
+      
+      for (let i = 1; i <= epCount; i++) {
+        if (animeInfo.episodes instanceof Array) {
+          animeInfo.episodes.push({
+            number: i,
+            slug: slug + "-" + seasonNumber + "x" + i,
+            url: ANIMEAV1_BASE + "/episode/" + slug + "-" + seasonNumber + "x" + i
+          });
+        }
+      }
+
+      //Relacionados
+      const relatedEls = $("#seasonsNav > div.season-tab").not(".active");
+      const relatedAnimes = [];
+      relatedEls.each((_, el) => {
+        const title = $(el).find(".tab-title").text().trim();
+        const relation = "TEMPORADAS";//$(el).find(".tab-title").text().trim();
+        if (title) {
+          const slugi = `${slug}#season-${title.replace("TEMPORADA", "").trim()}`;
+          relatedAnimes.push({
+            title,
+            relation,
+            slug: slugi,
+            url: `${ANIMEJARA_BASE}/anime/${slugi}`
+          });
+        }
+      });
+
+      //Asigna la propiedad si hay elementos
+      if (relatedAnimes.length > 0) {
+        animeInfo.related = relatedAnimes;
+      }
+    }
+
+    return animeInfo;
+  } catch (error) {
+    console.error("Error al obtener la información del anime", slug, error);
+    throw error
+  }
+}
+//Adapted from TypeScript from https://github.com/ahmedrangel/animeflv-api/blob/main/server/utils/scrapers/getEpisodeLinks.ts
+async function SearchAnimesBySpecificURL(animejaraURL) {
+  try {
+    const html = await fetch(decodeURIComponent(animejaraURL)).then((resp) => {
+      if ((!resp.ok) || resp.status !== 200) throw Error(`HTTP error! Status: ${resp.status}`)
+      if (resp === undefined) throw Error(`Undefined response!`)
+      return resp.text()
+    })
+    const $ = cheerio.load(html);
+
+    const search = {
+      currentPage: 1,
+      hasNextPage: false,
+      previousPage: null,
+      nextPage: null,
+      foundPages: 0,
+      media: []
+    };
+
+    const pageSelector = $("#m > section > ul.pag > li");
+    const getNextAndPrevPages = (selector) => {
+      let aTagValue = selector.last().prev().find("a").text();
+      if (aTagValue.includes("Siguiente")) aTagValue = selector.last().prev().prev().find("a").text();
+      let aRef = selector.eq(0).children("a");
+      if (aRef.text().includes("Inicio")) aRef = selector.eq(1).children("a");
+
+      let foundPages = 0;
+      let previousPage = "";
+      let nextPage = "";
+
+      if (Number(aTagValue) === 0) foundPages = 1;
+      else foundPages = Number(aTagValue);
+
+      if (aRef.text() === "1" || foundPages == 1) previousPage = null;
+      else previousPage = ANIMEJARA_BASE + aRef.attr("href");
+
+      if (!selector.last().children("a").text().includes("Último") || foundPages == 1) nextPage = null;
+      else nextPage = ANIMEJARA_BASE + selector.last().prev().find("a").attr("href");
+
+      return { foundPages, nextPage, previousPage };
+    }
+    const { foundPages, nextPage, previousPage } = getNextAndPrevPages(pageSelector)
+    const scrapSearchAnimeData = ($) => {
+      const selectedElement = $("#m > section > div > article");
+
+      if (selectedElement.length > 0) {
+        const mediaVec = [];
+
+        selectedElement.each((_, el) => {
+          mediaVec.push({
+            title: $(el).find("h3").text() || $(el).find("figure > a > img").attr("alt"),
+            cover: $(el).find("figure > a > img").attr("data-src"),
+            //synopsis: $(el).find("div > div > div > p").eq(1).text(),
+            //rating: $(el).find("article > div > p:nth-child(2) > span.Vts.fa-star").text(),
+            slug: $(el).find("a").attr("href").replace("./anime/", ""),
+            type: $(el).find("figure > a > b").text(),
+            url: ANIMEJARA_BASE + ($(el).find("a").attr("href").replace('.', '') || $(el).find("h3 > a").attr("href").replace('.', '')),
+          });
+        });
+        return mediaVec
+      }
+      else {
+        return [];
+      }
+    }
+    search.media.push(...scrapSearchAnimeData($));
+    search.foundPages = foundPages;
+    search.nextPage = nextPage;
+    search.previousPage = previousPage;
+    const getPage = (url) => new URL(url).searchParams.get("page")
+    const pageFromQuery = nextPage ? Number(getPage(nextPage)) : previousPage ? Number(getPage(previousPage)) : null;
+    const isNextPage = nextPage && pageFromQuery;
+    const isPreviousPage = previousPage && pageFromQuery;
+    const inferredPage = isNextPage ? pageFromQuery - 1 : isPreviousPage ? pageFromQuery + 1 : null;
+    search.currentPage = inferredPage || 1;
+    search.hasNextPage = nextPage ? true : false;
+    return search;
+  } catch (error) {
+    console.error("Error al buscar animes por URL:", error);
+    throw error
+  }
+}
+
+async function GetOnAir() {
+  return SearchAnimesBySpecificURL(`${decodeURIComponent(ANIMEJARA_BASE)}/inicio`).then((data) => {
+    if (!data || data.media === undefined) throw Error("Invalid response!")
+    return data.media.map((anime) => {
+      return {
+        title: anime.title,
+        type: anime.type,
+        slug: anime.slug,
+        url: anime.url
+      }
+    })
+  })
+}

--- a/routes/catalog.js
+++ b/routes/catalog.js
@@ -252,7 +252,7 @@ function ParseConfig(req, res, next) {
 //Calendar requests
 catalog.get("/catalog/series/calendar-videos/:calendarVideosIds(calendarVideosIds=(?:\\S{0,},?){0,}).json", (req, res) => {
   let metasDetailed = [], uniqueIDs = [...new Set(req.params.calendarVideosIds.slice(18).split(',')//filter idPrefixes not covered by other meta providers
-    .filter((id) => id.startsWith("animeflv:") /*|| id.startsWith("animeav1:") || id.startsWith("henaojara:")*/ || id.startsWith("tioanime:") || id.startsWith("anilist:") || id.startsWith("kitsu:") || id.startsWith("mal:") || id.startsWith("anidb:")))]
+    .filter((id) => id.startsWith("animeflv:") /*|| id.startsWith("animeav1:") || id.startsWith("henaojara:")*/ || id.startsWith("tioanime:") || id.startsWith("animejara:") || id.startsWith("anilist:") || id.startsWith("kitsu:") || id.startsWith("mal:") || id.startsWith("anidb:")))]
 
   console.log("Unique IDs:", uniqueIDs)
 
@@ -275,6 +275,10 @@ catalog.get("/catalog/series/calendar-videos/:calendarVideosIds(calendarVideosId
       const ID = idDetails[1]
       console.log(`\x1b[33mGot ${videoID} ID:\x1b[39m ${ID}`)
       return tioanimeAPI.GetAnimeBySlug(ID)
+    } else if (videoID.startsWith("animejara")) {
+      const ID = idDetails[1]
+      console.log(`\x1b[33mGot ${videoID} ID:\x1b[39m ${ID}`)
+      return animejaraAPI.GetAnimeBySlug(ID, "series") //only series have upcoming eps
     } else {
       let animeIMDBIDPromise
       const ID = idDetails[1] //We want the second part of the videoID, which is the kitsu ID

--- a/routes/catalog.js
+++ b/routes/catalog.js
@@ -9,6 +9,7 @@ const animeFLVAPI = require('./animeFLV.js')
 const animeAV1API = require('./animeav1.js')
 const henaojaraAPI = require('./henaojara.js')
 const tioanimeAPI = require('./tioanime.js')
+const animejaraAPI = require('./animejara.js')
 
 /**
  * Tipical express middleware callback.
@@ -140,6 +141,43 @@ function HandleCatalogRequest(req, res, next) {
         return result.map((anime) => {
           return {
             id: `tioanime:${anime.slug}`,
+            type: anime.type,
+            name: anime.title,
+            poster: anime.poster,
+            description: anime.overview,
+            genres: (anime.genres) ? anime.genres.map((el) => el.slice(0, 1).toUpperCase() + el.slice(1)) : undefined
+          }
+        })
+      })
+    }
+  } else if (req.params.videoId.startsWith("animejara")) {
+    //animejara catalog request
+    if (res.locals.extraParams && !req.params.videoId.includes("onair")) {
+      let genreArr = res.locals.extraParams.genre
+      //calculate the page to start from, TioAnime uses 20 results per page
+      //if skip is defined, we can calculate the page and the number of items we already delivered
+      let page = (res.locals.extraParams.skip) ? Math.floor(res.locals.extraParams.skip / 20) + 1 : undefined,
+        gottenItems = (res.locals.extraParams.skip) ? res.locals.extraParams.skip % 20 : undefined
+      console.log("Skipping to page:", page, "with", gottenItems, "items already delivered")
+      catalogPromise = animejaraAPI.SearchAnimeJara(res.locals.extraParams.search, undefined, genreArr, undefined, page, gottenItems).then((result) => {
+        console.log('\x1b[36mGot AnimeJara metadata for:\x1b[39m', result.length, "search results")
+        return result.map((anime) => {
+          return {
+            id: `animejara:${anime.slug}`,
+            type: anime.type,
+            name: anime.title,
+            poster: anime.poster,
+            description: anime.overview,
+            genres: (anime.genres) ? anime.genres.map((el) => el.slice(0, 1).toUpperCase() + el.slice(1)) : undefined
+          }
+        })
+      })
+    } else {
+      catalogPromise = animejaraAPI.GetAiringAnime().then((result) => {
+        console.log('\x1b[36mGot AnimeJara metadata for:\x1b[39m', result.length, "search results")
+        return result.map((anime) => {
+          return {
+            id: `animejara:${anime.slug}`,
             type: anime.type,
             name: anime.title,
             poster: anime.poster,

--- a/routes/henaojara.js
+++ b/routes/henaojara.js
@@ -158,15 +158,6 @@ async function GetEpisodeLinks(slug, epNumber = 1) {
     
     const downloadObj = JSON.parse(serversDIV.attr("data-dwn") || "null");
 
-    const getServerTitle = (serverDomain) => {
-      const cleanDom = serverDomain.replace("bysesukior", "Filemoon").replace("movearnpre", "Vidhide")
-        .replace("luluvdo", "Lulustream").replace("dhcplay", "Streamwish").replace("listeamed", "Vidguard")
-        .replace("rpmvip", "RPMshare").replace("yourupload", "YourUpload").replace("mp4upload", "MP4Upload")
-        .replace("pdrain", "PDrain").replace("hls", "HLS")
-        .replace(".com", "").replace(".net", "").replace(".org", "").replace(".top", "")
-        .replace(".to", "").replace(".ac", "").replace(".sx", "").replace(".ps", "");
-      return cleanDom.charAt(0).toUpperCase() + cleanDom.slice(1)
-    }
     const hex2a = (hex) => { var str = ''; for (var i = 0; i < hex.length; i += 2) str += String.fromCharCode(parseInt(hex.substr(i, 2), 16)); return str;};
     const serverData = async () => {
       return await fetch(`${HENAOJARA_BASE}/hj`, {
@@ -200,7 +191,7 @@ async function GetEpisodeLinks(slug, epNumber = 1) {
         const s = hex2a($(el).attr("encrypt"));
         const sURL = new URL(s)
         episodeLinks.servers.push({
-          name: getServerTitle(sURL.hostname),
+          name: streamParser.getServerTitle(sURL.hostname),
           embed: s?.replace("mega.nz/embed#!", "mega.nz/embed/"),
           dub: false
         });
@@ -210,7 +201,7 @@ async function GetEpisodeLinks(slug, epNumber = 1) {
       for (const s of downloadObj) {
         const sURL = new URL(s)
         episodeLinks.servers.push({
-          name: getServerTitle(sURL.hostname),
+          name: streamParser.getServerTitle(sURL.hostname),
           download: s?.replace("mega.nz/#!", "mega.nz/file/"),
           dub: false
         });

--- a/routes/meta.js
+++ b/routes/meta.js
@@ -9,6 +9,7 @@ const animeFLVAPI = require('./animeFLV.js')
 const animeAV1API = require('./animeav1.js')
 const henaojaraAPI = require('./henaojara.js')
 const tioanimeAPI = require('./tioanime.js')
+const animejaraAPI = require('./animejara.js')
 const fuzzysort = require('fuzzysort')
 
 /**
@@ -46,7 +47,7 @@ function HandleMetaRequest(req, res, next) {
       }
     })
   } else if (videoID?.startsWith("animeav1")){
-    const ID = idDetails[1] //We want the second part of the videoID, which is the kitsu ID
+    const ID = idDetails[1]
     let episode = idDetails[2] //undefined if we don't get an episode number in the query, which is fine
     console.log(`\x1b[33mGot a ${req.params.type} with ${videoID} ID:\x1b[39m ${ID}`)
     animeAV1API.GetAnimeBySlug(ID).then((animeMeta) => {
@@ -63,7 +64,7 @@ function HandleMetaRequest(req, res, next) {
       }
     })
   } else if (videoID?.startsWith("henaojara")){
-    const ID = idDetails[1] //We want the second part of the videoID, which is the kitsu ID
+    const ID = idDetails[1]
     let episode = idDetails[2] //undefined if we don't get an episode number in the query, which is fine
     console.log(`\x1b[33mGot a ${req.params.type} with ${videoID} ID:\x1b[39m ${ID}`)
     henaojaraAPI.GetAnimeBySlug(ID).then((animeMeta) => {
@@ -80,7 +81,7 @@ function HandleMetaRequest(req, res, next) {
       }
     })
   } else if (videoID?.startsWith("tioanime")){
-    const ID = idDetails[1] //We want the second part of the videoID, which is the kitsu ID
+    const ID = idDetails[1]
     let episode = idDetails[2] //undefined if we don't get an episode number in the query, which is fine
     console.log(`\x1b[33mGot a ${req.params.type} with ${videoID} ID:\x1b[39m ${ID}`)
     tioanimeAPI.GetAnimeBySlug(ID).then((animeMeta) => {
@@ -93,6 +94,24 @@ function HandleMetaRequest(req, res, next) {
       if (!res.headersSent) {
         res.header('Cache-Control', "max-age=86400, stale-while-revalidate=86400, stale-if-error=259200")
         res.json({ meta: {}, message: "Failed getting TioAnime info" });
+        next()
+      }
+    })
+  } else if (videoID?.startsWith("animejara")){
+    const ID = idDetails[1] 
+    let season = idDetails[2] //undefined if we don't get an season number in the query, which is fine
+    let episode = idDetails[3] //undefined if we don't get an episode number in the query, which is fine
+    console.log(`\x1b[33mGot a ${req.params.type} with ${videoID} ID:\x1b[39m ${ID}`)
+    animejaraAPI.GetAnimeBySlug(ID, req.params.type).then((animeMeta) => {
+      console.log('\x1b[36mGot AnimeJara metadata for:\x1b[39m', animeMeta.name)
+      res.header('Cache-Control', "max-age=86400, stale-while-revalidate=86400, stale-if-error=259200")
+      res.json({ meta: animeMeta, message: "Got AnimeJara metadata!" })
+      next()
+    }).catch((err) => {
+      console.error('\x1b[31mFailed on AnimeJara slug search because:\x1b[39m ' + err)
+      if (!res.headersSent) {
+        res.header('Cache-Control', "max-age=86400, stale-while-revalidate=86400, stale-if-error=259200")
+        res.json({ meta: {}, message: "Failed getting AnimeJara info" });
         next()
       }
     })

--- a/routes/streams.js
+++ b/routes/streams.js
@@ -9,6 +9,7 @@ const animeFLVAPI = require('./animeFLV.js')
 const animeAV1API = require('./animeav1.js')
 const henaojaraAPI = require('./henaojara.js')
 const tioanimeAPI = require('./tioanime.js')
+const animejaraAPI = require('./animejara.js')
 const fuzzysort = require('fuzzysort')
 
 /**
@@ -41,16 +42,22 @@ function HandleStreamRequest(req, res, next) {
   let streams = []
   const idDetails = req.params.videoId.split(':')
   const videoID = idDetails[0] //We only want the first part of the videoID, which is the IMDB ID, the rest would be the season and episode
-  if ((videoID?.startsWith("animeflv")) || (videoID?.startsWith("animeav1")) || (videoID?.startsWith("henaojara")) || (videoID?.startsWith("tioanime"))) { //If we got an AnimeFLV or AnimeAV1 specific ID
+  if ((videoID?.startsWith("animeflv")) || (videoID?.startsWith("animeav1")) || (videoID?.startsWith("henaojara")) || (videoID?.startsWith("tioanime")) || (videoID?.startsWith("animejara"))) { //If we got an AnimeFLV or AnimeAV1 specific ID
     const ID = idDetails[1] //We want the second part of the videoID
     let episode = idDetails[2] //undefined if we don't get an episode number in the query, which is fine
+    let season
+    if(videoID?.startsWith("animejara")){
+      season = idDetails[2]
+      episode = idDetails[3]
+    }
     console.log(`\x1b[33mGot a ${req.params.type} with ${videoID} ID:\x1b[39m ${ID}`)
     console.log('Extra parameters:', res.locals.extraParams)
     const animeFLVp = animeFLVAPI.GetItemStreams(ID, onlyInternal, episode)
     const animeAV1p = animeAV1API.GetItemStreams(ID, onlyInternal, episode)
     const henaojarap = henaojaraAPI.GetItemStreams(ID, onlyInternal, episode)
     const tioanimep = tioanimeAPI.GetItemStreams(ID, onlyInternal, episode)
-    CombineStreams(animeFLVp, animeAV1p, henaojarap, tioanimep).then((combinedStreams)=>{
+    const animejarap = animejaraAPI.GetItemStreams(ID, onlyInternal, season, episode)
+    CombineStreams(animeFLVp, animeAV1p, henaojarap, tioanimep, animejarap).then((combinedStreams)=>{
       if (combinedStreams.length > 0) {
         console.log(`\x1b[36mGot ${combinedStreams.length} streams\x1b[39m`)
         res.header('Cache-Control', "max-age=86400, stale-while-revalidate=86400, stale-if-error=259200")
@@ -143,7 +150,12 @@ function HandleStreamRequest(req, res, next) {
         console.log('\x1b[36mGot TioAnime entry:\x1b[39m', result.title)
         return tioanimeAPI.GetItemStreams(result.slug, onlyInternal, episode)
       })
-      CombineStreams(animeFLVp, animeAV1p, henaojarap, tioanimep).then((combinedStreams)=>{
+      const animejarap = animejaraAPI.SearchAnimeJara(searchTerm, req.params.type).then((animeFLVitem) => {
+        const result = fuzzysort.go(searchTerm, animeFLVitem, {key: 'title', limit: 1})[0]?.obj || animeFLVitem[0];
+        console.log('\x1b[36mGot AnimeJara entry:\x1b[39m', result.title)
+        return animejaraAPI.GetItemStreams(result.slug, onlyInternal, season, episode)
+      })
+      CombineStreams(animeFLVp, animeAV1p, henaojarap, tioanimep, animejarap).then((combinedStreams)=>{
         if (combinedStreams.length > 0) {
           console.log(`\x1b[36mGot ${combinedStreams.length} streams\x1b[39m`)
           res.header('Cache-Control', "max-age=86400, stale-while-revalidate=86400, stale-if-error=259200")
@@ -206,8 +218,8 @@ function SearchParamsRegex(extraParams) {
   } else return {}
 }
 
-function CombineStreams(animeFLVPromise, animeAV1Promise, henaojaraPromise, tioanimePromise) {
-  return Promise.allSettled([animeFLVPromise, animeAV1Promise, henaojaraPromise, tioanimePromise]).then((results) => {
+function CombineStreams(animeFLVPromise, animeAV1Promise, henaojaraPromise, tioanimePromise, animejaraPromise) {
+  return Promise.allSettled([animeFLVPromise, animeAV1Promise, henaojaraPromise, tioanimePromise, animejaraPromise]).then((results) => {
     let combinedStreams = []
     if (results[0].value) {
       console.log(`\x1b[36mGot ${results[0].value.length} AnimeFLV streams\x1b[39m`)
@@ -252,6 +264,19 @@ function CombineStreams(animeFLVPromise, animeAV1Promise, henaojaraPromise, tioa
         combinedStreams = combinedStreams.concat(results[3].value.slice(lastInternalTio + 1)) //Append external links at the end
       }
     } else {console.error('\x1b[31mFailed on TioAnime slug search because:\x1b[39m ' + results[3].reason)}
+    if (results[4].value) {
+      console.log(`\x1b[36mGot ${results[4].value.length} AnimeJara streams\x1b[39m`)
+      lastInternal = combinedStreams.findLastIndex((stream)=>stream.url !== undefined)
+      lastInternalJara = results[4].value.findLastIndex((stream)=>stream.url !== undefined)
+      if (lastInternalJara === -1) {
+        combinedStreams = combinedStreams.concat(results[4].value) //AnimeJara has only external links, just append at the end
+      } else if ((lastInternalJara !== -1) && (lastInternal === -1)) {
+        combinedStreams = results[4].value.concat(combinedStreams) //Previous has only external links, prepend at the start
+      } else {
+        combinedStreams.splice(lastInternal + 1, 0, ...results[4].value.slice(0, lastInternalJara + 1)) //Both have internal links, insert AnimeJara internal links after last internal links
+        combinedStreams = combinedStreams.concat(results[4].value.slice(lastInternalJara + 1)) //Append external links at the end
+      }
+    } else {console.error('\x1b[31mFailed on AnimeJara slug search because:\x1b[39m ' + results[4].reason)}
     return combinedStreams
   })
 }

--- a/routes/tioanime.js
+++ b/routes/tioanime.js
@@ -37,7 +37,7 @@ exports.UpdateAiringAnimeFile = function () {
   return this.GetAiringAnimeFromWeb().then((titles) => {
     console.log(`\x1b[36mGot ${titles.length} titles\x1b[39m, saving to cache`)
     return fsPromises.writeFile('./onair_titlesTIO.json', JSON.stringify(titles))
-  }).then(() => console.log('\x1b[32mOn Air titles "cached" successfully!\x1b[39m')
+  }).then(() => console.log('\x1b[32mOn Air TioAnime titles "cached" successfully!\x1b[39m')
   ).catch((err) => {
     console.error('\x1b[31mFailed "caching" titles:\x1b[39m ' + err)
   })

--- a/views/content.ejs
+++ b/views/content.ejs
@@ -8,6 +8,7 @@
       <label style="display:block"><img style="height:1.2em" src="https://animeav1.com/img/logo-dark.svg" alt="AnimeAV1"> <input style="vertical-align:top" type="checkbox" id="animeav1"<%= (config?.get("onAirCatalogs").includes("animeav1"))?` checked="true"`:"" %>></label>
       <label style="display:block"><img style="height:1em" src="https://www.henaojara.com/wp-content/uploads/2021/04/INICIO_new.png" alt="Henaojara"> <input style="vertical-align:top" type="checkbox" id="henaojara"<%= (config?.get("onAirCatalogs").includes("henaojara"))?` checked="true"`:"" %>></label>
       <label style="display:block"><img style="height:1.4em" src="https://tioanime.com/assets/img/logo-dark.png" alt="TioAnime"> <input style="vertical-align:top" type="checkbox" id="tioanime"<%= (config?.get("onAirCatalogs").includes("tioanime"))?` checked="true"`:"" %>></label>
+      <label style="display:block"><img style="height:1.4em" src="https://animejara.com/wp-content/uploads/2025/11/ANIMEJARA_INICIO3.png" alt="AnimeJara"> <input style="vertical-align:top" type="checkbox" id="animejara"<%= (config?.get("onAirCatalogs").includes("animejara"))?` checked="true"`:"" %>></label>
     </div>
     </label>
     <label class="full-width label-to-top" style="display:block" for="manifest_url">Your manifest URL:</label>
@@ -26,8 +27,8 @@
     <button tabindex="-1" class="full-width">Open In Stremio</button>
   </a>
   <script>const ta=document.getElementById('manifest_url');const externalStreams=document.getElementById('externalStreams')
-    const animeflv=document.getElementById('animeflv');const animeav1=document.getElementById('animeav1');const henaojara=document.getElementById('henaojara');const tioanime=document.getElementById('tioanime');
-    const providers=[animeflv,animeav1,henaojara,tioanime]
+    const animeflv=document.getElementById('animeflv');const animeav1=document.getElementById('animeav1');const henaojara=document.getElementById('henaojara');const tioanime=document.getElementById('tioanime');const animejara=document.getElementById('animejara');
+    const providers=[animeflv,animeav1,henaojara,tioanime,animejara]
     const installLink=document.getElementById('installLink')
     function genManifLink(){
       let config=new URLSearchParams();


### PR DESCRIPTION
This adds support for AnimeJara. It's not as compatible as the other providers in terms of ID's, because AnimeJara groups seasons, same as Cinemeta or TMDB instead of each season being a different item. It doesn't provide relations (spinoffs, etc) or background images, so metadata is not ideal.

The advantage, on the other hand, is just that: it can help mitigate false negatives in streams from Cinemeta/IMDB/TMDB etc. because it incorporates seasons natively (which is done manually in the other services). It also differentiates between dub "flavours" (Spanish from Latin America and from Spain) as we want in #37. More streams in general, and dub options and detail on their flavour are always a nice addition.

Lastly, as AnimeJara provides next episode dates, it could also be a nice addition to the calendar.